### PR TITLE
Bug correction proposal

### DIFF
--- a/R/predict.bicreg.R
+++ b/R/predict.bicreg.R
@@ -123,7 +123,7 @@ s"))
         return(asgn)
     }
 
-    newdata <- as.data.frame(newdata[,object$input.names])
+    newdata <- as.data.frame(newdata[,object$namesx])
     nObs <- nrow(newdata)
     callList <- as.list(object$call)
     callFunc <- callList[[1]]


### PR DESCRIPTION
I've encountred some bugs with object$input.names which are somehow different than object$namesx. 
predict.bicreg througs an error when object$input.names != object$namesx. 
This happens when giving a large set of variables to the bicreg function (more than 30 in my experience). bicreg performs a selction and eliminates some of them which leads to object$input.names != object$namesx